### PR TITLE
Fix liquidation price

### DIFF
--- a/src/tradingkit/display/highstock/highstock_plotter.py
+++ b/src/tradingkit/display/highstock/highstock_plotter.py
@@ -75,10 +75,6 @@ class HighstockPlotter(Plotter):
         if isinstance(event, Plot):
             plot = event.payload
             if plot['name'].lower() == 'price':
-                if self.balance['position_price'] != 0 and self.balance['position_price'] is not None:
-                    pnl = (plot['data']['close'] / self.balance['position_price'] - 1) * self.balance['position_vol']
-                else:
-                    pnl = 0
                 date = int(datetime.timestamp(datetime.fromisoformat(plot['data']['datetime']))) * 1000
                 self.series['OHLC']['data'].append([date,
                                                     plot['data']['open'],
@@ -92,7 +88,7 @@ class HighstockPlotter(Plotter):
                     liq_price = None
                 self.series['liq_price']['data'].append([date, liq_price])
                 self.series['volume']['data'].append([date, plot['data']['vol']])
-                y = round(self.balance['quote_balance'] + self.balance['base_balance'] * plot['data']['close'] + pnl)
+                y = round(self.balance['quote_balance'] + self.balance['base_balance'] * plot['data']['close'])
                 self.series['equity']['data'].append([date, y])
 
                 self.series['base_equity']['data'].append([date,

--- a/src/tradingkit/exchange/bitmex_backtest.py
+++ b/src/tradingkit/exchange/bitmex_backtest.py
@@ -166,8 +166,8 @@ class BitmexBacktest(TestEX):
             if self.position['currentQty'] < 0:
                 sum_same_side_orders = -sum_same_side_orders
 
-            self.position['liquidationPrice'] = self.position['avgEntryPrice'] * (1 - self.balance[base] * mark_price /
-                                                     (self.position['currentQty'] + sum_same_side_orders))
+            self.position['liquidationPrice'] = self.position['avgEntryPrice'] * max(
+                0, (1 - self.balance[base] * mark_price / (self.position['currentQty'] + sum_same_side_orders)))
         else:
             self.position['liquidationPrice'] = None
 


### PR DESCRIPTION
Implemented **fetch_balance** method in bitmex_backtest to include **wallet_balance** value.

Fixed **liquidation_price** bug that show negative price on long position and leverage below 1X.

closes #2 